### PR TITLE
Pint Unit for Water

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,7 @@
 ----------
 - [@boreshnavard](https://github.com/boreshnavard) **
 - [@AHReccese](https://github.com/AHReccese)
+- [@sadrasabouri](https://github.com/sadrasabouri)
 
 
 ** Graphic designer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- 1 new water unit
+	1. Pint (`pt`)
 ## [0.9] - 2024-12-06
 ### Added
 - 4 new water units

--- a/mycoffee/params.py
+++ b/mycoffee/params.py
@@ -216,4 +216,5 @@ WATER_UNITS_MAP = {
     "tsp": {"name": "teaspoon", "rate": 0.20288},
     "dsp": {"name": "dessertspoon", "rate": 0.10144},
     "cup": {"name": "cup", "rate": 0.0042268},
+    "pt": {"name": "pint", "rate": 0.00211338},
 }

--- a/test/functions_test.py
+++ b/test/functions_test.py
@@ -159,12 +159,13 @@ Water units list:
 3. `g` - gram
 4. `kg` - kilogram
 5. `l` - liter
-6. `lb` - pound
-7. `mg` - milligram
-8. `ml` - milliliter
-9. `oz` - ounce
-10. `tbsp` - tablespoon
-11. `tsp` - teaspoon
+6. `pt` - pint
+7. `lb` - pound
+8. `mg` - milligram
+9. `ml` - milliliter
+10. `oz` - ounce
+11. `tbsp` - tablespoon
+12. `tsp` - teaspoon
 >>> test_params = {"method":"v60", "cups":1, "water":335, "coffee_ratio": 3, "water_ratio":50, "info":"V60 method", 'coffee_unit': 'g'}
 >>> calc_coffee(test_params)
 20.1
@@ -407,10 +408,10 @@ Water units list:
 3. `g` - gram
 4. `kg` - kilogram
 5. `l` - liter
-6. `lb` - pound
-7. `mg` - milligram
-8. `ml` - milliliter
-9. `oz` - ounce
-10. `tbsp` - tablespoon
-11. `tsp` - teaspoon
+6. `pt` - pint
+7. `lb` - pound
+8. `mg` - milligram
+9. `ml` - milliliter
+10. `oz` - ounce
+11. `tbsp` - tablespoon
 """

--- a/test/functions_test.py
+++ b/test/functions_test.py
@@ -158,12 +158,12 @@ Water units list:
 2. `dsp` - dessertspoon
 3. `g` - gram
 4. `kg` - kilogram
-5. `l` - liter
-6. `pt` - pint
-7. `lb` - pound
-8. `mg` - milligram
-9. `ml` - milliliter
-10. `oz` - ounce
+5. `l` - liter 
+6. `lb` - pound
+7. `mg` - milligram
+8. `ml` - milliliter
+9. `oz` - ounce
+10. `pt` - pint
 11. `tbsp` - tablespoon
 12. `tsp` - teaspoon
 >>> test_params = {"method":"v60", "cups":1, "water":335, "coffee_ratio": 3, "water_ratio":50, "info":"V60 method", 'coffee_unit': 'g'}
@@ -407,11 +407,12 @@ Water units list:
 2. `dsp` - dessertspoon
 3. `g` - gram
 4. `kg` - kilogram
-5. `l` - liter
-6. `pt` - pint
-7. `lb` - pound
-8. `mg` - milligram
-9. `ml` - milliliter
-10. `oz` - ounce
+5. `l` - liter 
+6. `lb` - pound
+7. `mg` - milligram
+8. `ml` - milliliter
+9. `oz` - ounce
+10. `pt` - pint
 11. `tbsp` - tablespoon
+12. `tsp` - teaspoon
 """

--- a/test/verified_test.py
+++ b/test/verified_test.py
@@ -347,4 +347,8 @@ True
 True
 >>> convert_water(240, "cup", True) == 56780.54320052995 # https://www.howmany.wiki/wv/
 True
+>>> round(convert_water(240, "pt"), 5) == 0.50721 # https://www.inchcalculator.com/convert/milliliter-to-pint/
+True
+>>> int(convert_water(240, "pt", True)) == 113562 # https://www.inchcalculator.com/convert/milliliter-to-pint/
+True
 """


### PR DESCRIPTION
#### Reference Issues/PRs
#47 
#### What does this implement/fix? Explain your changes.
Pint unit for water added based on [this](https://www.inchcalculator.com/convert/milliliter-to-pint/) link.

#### Any other comments?
I think the website is not accurate enough (number of floating points) that's why I use `round` in the tests.
If you don't like it @sepandhaghighi we can change the source to Google Units which is better.